### PR TITLE
[FIX] Update based on depend library changes

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -237,7 +237,7 @@ impl<'a> Iterator for FormatParser<'a> {
 
                         // Collect the attributes into attrs and color, for use as properties
                         // of a FormatUnit.
-                        for word in buffer.split_whitespace() {
+                        for word in buffer.split(|c: char| c.is_whitespace()) {
                             match word {
                                 "A" => attrs = self.attrs.next().unwrap_or(ConstantAttrs(vec![])),
 
@@ -427,4 +427,3 @@ pub struct FormatUnit {
     pub color: FormatColor,
     pub attrs: FormatAttr
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate term;
 
 use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Response, status};
 use iron::typemap::Key;
-use term::{Terminal, stdout};
+use term::{StdoutTerminal, stdout};
 
 use std::io;
 use std::error::Error;
@@ -81,7 +81,7 @@ impl AfterMiddleware for Logger {
                 }
             };
 
-            let log = |mut t: Box<Terminal<io::Stdout> + Send>| -> io::Result<()> {
+            let log = |mut t: Box<StdoutTerminal>| -> io::Result<()> {
                 for unit in format.iter() {
                     match unit.color {
                         ConstantColor(Some(color)) => { try!(t.fg(color)); }


### PR DESCRIPTION
API for Terminal seems to have changed

Also, String `.split_whitespace()` no longer seems to exist

Now builds and test passing, so assume it's OK.  Happy to make more adjustments if required :smile: