### PR TITLE
(fix) Update term to 0.4, use the new Result type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT"
 [dependencies]
 iron = { version = "0.2", default-features = false }
 time = "0.1"
-term = "0.2"
+term = { git = "https://github.com/Stebalien/term.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "MIT"
 [dependencies]
 iron = { version = "0.2", default-features = false }
 time = "0.1"
-term = { git = "https://github.com/Stebalien/term.git" }
+term = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate term;
 
 use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Response, status};
 use iron::typemap::Key;
-use term::{StdoutTerminal, color, stdout};
+use term::{StdoutTerminal, color, stdout, Result as TermResult};
 
 use std::io;
 use std::io::Write;
@@ -117,8 +117,8 @@ impl Logger {
 }
 
 trait LogWriter {
-    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> io::Result<()>;
-    fn new_line(&mut self) -> io::Result<()>;
+    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> TermResult<()>;
+    fn new_line(&mut self) -> TermResult<()>;
 }
 
 struct TermWriter {
@@ -134,7 +134,7 @@ impl TermWriter {
 }
 
 impl LogWriter for TermWriter {
-    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> io::Result<()> {
+    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> TermResult<()> {
         match color {
             Some(c) => { try!(self.term.fg(c)); }
             None => {},
@@ -147,19 +147,19 @@ impl LogWriter for TermWriter {
         Ok(())
     }
 
-    fn new_line(&mut self) -> io::Result<()> {
+    fn new_line(&mut self) -> TermResult<()> {
         try!(writeln!(self.term, ""));
         Ok(())
     }
 }
 
 impl<T: Write> LogWriter for T {
-    fn write_item(&mut self, text: String, _: Option<color::Color>, _: &Vec<term::Attr>) -> io::Result<()> {
+    fn write_item(&mut self, text: String, _: Option<color::Color>, _: &Vec<term::Attr>) -> TermResult<()> {
         try!(write!(self, "{}", text));
         Ok(())
     }
 
-    fn new_line(&mut self) -> io::Result<()> {
+    fn new_line(&mut self) -> TermResult<()> {
         try!(writeln!(self, ""));
         Ok(())
     }


### PR DESCRIPTION
I've been having issues with logger and the Docker Ubuntu image where logger will cause the container to silently 500 to all requests, making both my app and me very sad.

Updating to term 0.3 (unreleased at the moment) and updating logger's code to use term's new error type fixes the issue.

Issue on term to get 0.3 released: https://github.com/Stebalien/term/issues/51