### PR TITLE
Change iron dependency from 0.2 to 0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ keywords = ["iron", "web", "logger", "log", "timer"]
 license = "MIT"
 
 [dependencies]
-iron = { version = "0.2", default-features = false }
+iron = { version = "0.3", default-features = false }
 time = "0.1"
 term = "0.2"


### PR DESCRIPTION
I've bumped the version to fix a couple of problems with building with the latest iron, rust etc.

The current examples/default.rs fails with an InternalServerError in chain.link_after(logger_after); and compiling my app gets the same problem as described in https://github.com/iron/logger/issues/80.

I don't know if moving to the newer version is safe, but it is working for me so far.