### PR TITLE
Added field to print the request time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT"
 [dependencies]
 iron = { version = "0.4", default-features = false }
 term = "0.4"
+time = "0.1.35"

--- a/examples/formatstring.rs
+++ b/examples/formatstring.rs
@@ -12,7 +12,7 @@ use logger::format::FormatAttr::FunctionAttrs;
 use term::Attr;
 
 static FORMAT: &'static str =
-    "@[red A]Uri: {uri}@, @[blue blink underline]Method: {method}@, @[yellow standout]Status: {status}@, @[brightgreen]Time: {response-time}@";
+    "@[red A]Uri: {uri}@, @[blue blink underline]Method: {method}@, @[yellow standout]Status: {status}@, @[brightgreen]Duration: {response-time}@, Time: {request-time}";
 
 // This is an example of using a format string that can specify colors and attributes
 // to specific words that are printed out to the console.

--- a/src/format.rs
+++ b/src/format.rs
@@ -11,7 +11,7 @@ use std::vec::IntoIter;
 use std::iter::Peekable;
 
 use self::ColorOrAttr::{Color, Attr};
-use self::FormatText::{Method, URI, Status, ResponseTime, RemoteAddr};
+use self::FormatText::{Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
 use self::FormatColor::{ConstantColor, FunctionColor};
 use self::FormatAttr::{ConstantAttrs, FunctionAttrs};
 
@@ -53,7 +53,8 @@ impl Default for Format {
 impl Format {
     // TODO: Document the color/attribute tags.
     /// Create a `Format` from a format string, which can contain the fields
-    /// `{method}`, `{uri}`, `{status}`, `{response-time}`, and `{ip-addr}`.
+    /// `{method}`, `{uri}`, `{status}`, `{response-time}`, `{ip-addr}` and
+    /// `{request-time}`.
     ///
     /// Returns `None` if the format string syntax is incorrect.
     ///
@@ -177,6 +178,7 @@ impl<'a> Iterator for FormatParser<'a> {
             //   - {status}
             //   - {response-time}
             //   - {ip-addr}
+            //   - {request-time}
             Some('{') => {
                 self.object_buffer.clear();
 
@@ -196,6 +198,7 @@ impl<'a> Iterator for FormatParser<'a> {
                     "uri" => URI,
                     "status" => Status,
                     "response-time" => ResponseTime,
+                    "request-time" => RequestTime,
                     "ip-addr" => RemoteAddr,
                     _ => {
                         // Error, so mark as finished.
@@ -419,7 +422,8 @@ pub enum FormatText {
     URI,
     Status,
     ResponseTime,
-    RemoteAddr
+    RemoteAddr,
+    RequestTime
 }
 
 /// A `FormatText` with associated style information.


### PR DESCRIPTION
Added the {request-time} field which prints the time when the
request ocurred using the format "%Y-%m-%dT%H:%M:%S.%fZ%z".

Fix #69