### PR TITLE
Feat/noterm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "logger"
 version = "0.1.0"
-authors = ["Jonathan Reem <jonathan.reem@gmail.com>", "Michael Reinhard <mcreinhard@gmail.com>"]
+authors = ["Alexander Irbis <irbis.labs@gmail.com>", "Jonathan Reem <jonathan.reem@gmail.com>", "Michael Reinhard <mcreinhard@gmail.com>"]
 description = "Logging middleware for the Iron framework."
 repository = "https://github.com/iron/logger"
 keywords = ["iron", "web", "logger", "log", "timer"]
@@ -10,5 +10,5 @@ license = "MIT"
 
 [dependencies]
 iron = { version = "0.4", default-features = false }
-term = "0.4"
+log = "*"
 time = "0.1.35"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ license = "MIT"
 
 [dependencies]
 iron = { version = "0.4", default-features = false }
-log = "*"
+log = "0.3.6"
 time = "0.1.35"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ fn no_op_handler(_: &mut Request) -> IronResult<Response> {
 
 Logger is a part of Iron's [core bundle](https://github.com/iron/core).
 
-- Logger prints request and response information to the terminal, using either a default format or a custom format string.
-- Format strings can specify fields to be logged as well as ANSI terminal colors and attributes.
+Logger prints request and response information to the configured log, using either a default format or a custom format string.
+
+Format strings can specify fields to be logged (ANSI terminal colors and attributes is no longer supported).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Logger is a part of Iron's [core bundle](https://github.com/iron/core).
 
 Logger prints request and response information to the configured log, using either a default format or a custom format string.
 
-Format strings can specify fields to be logged (ANSI terminal colors and attributes is no longer supported).
+Format strings can specify fields to be logged (ANSI terminal colors and attributes is no longer supported since [#82](https://github.com/iron/logger/issues/82)).
 
 ## Installation
 

--- a/examples/formatstring.rs
+++ b/examples/formatstring.rs
@@ -1,31 +1,20 @@
 //! Example of logger with custom formatting
 extern crate iron;
 extern crate logger;
-extern crate term;
 
 use iron::prelude::*;
 
 use logger::Logger;
 use logger::format::Format;
-use logger::format::FormatAttr::FunctionAttrs;
-
-use term::Attr;
 
 static FORMAT: &'static str =
-    "@[red A]Uri: {uri}@, @[blue blink underline]Method: {method}@, @[yellow standout]Status: {status}@, @[brightgreen]Duration: {response-time}@, Time: {request-time}";
+    "Uri: {uri}, Method: {method}, Status: {status}, Duration: {response-time}, Time: {request-time}";
 
 // This is an example of using a format string that can specify colors and attributes
 // to specific words that are printed out to the console.
 fn main() {
-    fn attrs(req: &Request, _res: &Response) -> Vec<Attr> {
-        match format!("{}", req.url).as_ref() {
-            "/" => vec![Attr::Blink],
-            _ => vec![]
-        }
-    }
-
     let mut chain = Chain::new(no_op_handler);
-    let format = Format::new(FORMAT, vec![], vec![FunctionAttrs(attrs)]);
+    let format = Format::new(FORMAT);
     chain.link(Logger::new(Some(format.unwrap())));
     Iron::new(chain).http("localhost:3000").unwrap();
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,19 +1,10 @@
 //! Formatting helpers for the logger middleware.
 
-use iron::{Request, Response};
-use term::{self, color};
-use iron::status::NotFound;
-
 use std::default::Default;
-use std::str::FromStr;
 use std::str::Chars;
-use std::vec::IntoIter;
 use std::iter::Peekable;
 
-use self::ColorOrAttr::{Color, Attr};
 use self::FormatText::{Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
-use self::FormatColor::{ConstantColor, FunctionColor};
-use self::FormatAttr::{ConstantAttrs, FunctionAttrs};
 
 /// A formatting style for the `Logger`, consisting of multiple
 /// `FormatUnit`s concatenated into one line.
@@ -24,87 +15,23 @@ impl Default for Format {
     /// Return the default formatting style for the `Logger`:
     ///
     /// ```ignore
-    /// @[bold]{method}@ {uri} @[bold]->@ @[C]{status}@ ({response-time})
+    /// {method} {uri} -> {status} ({response-time})
     /// // This will be written as: {method} {uri} -> {status} ({response-time})
-    /// // with certain style attributes.
     /// ```
-    ///
-    /// The method is in bold, and the response status is colored blue for 100s,
-    /// green for 200s, yellow for 300s, red for 400s, and bright red for 500s.
     fn default() -> Format {
-        fn status_color(_req: &Request, res: &Response) -> Option<color::Color> {
-            use iron::status::StatusClass::*;
-
-            match res.status.unwrap_or(NotFound).class() {
-                Informational   => Some(color::BLUE),
-                Success         => Some(color::GREEN),
-                Redirection     => Some(color::YELLOW),
-                ClientError     => Some(color::RED),
-                ServerError     => Some(color::BRIGHT_RED),
-                NoClass         => None
-            }
-        }
-
-        Format::new("@[bold]{method}@ {uri} @[bold]->@ @[C]{status}@ ({response-time})",
-           vec![FunctionColor(status_color)], vec![]).unwrap()
+        Format::new("{method} {uri} {status} ({response-time})").unwrap()
     }
 }
 
 impl Format {
-    // TODO: Document the color/attribute tags.
     /// Create a `Format` from a format string, which can contain the fields
     /// `{method}`, `{uri}`, `{status}`, `{response-time}`, `{ip-addr}` and
     /// `{request-time}`.
     ///
     /// Returns `None` if the format string syntax is incorrect.
-    ///
-    /// ---
-    ///
-    /// Colors and attributes can also be added to the format string within `@` delimiters,
-    /// by specifying them in a space-delimited list within square brackets (`[bold italic]`).
-    /// They can be made dependent on the request/response by passing `FunctionColor` and
-    /// `FunctionAttr`s in as the `colors` and `attrs` vecs; these colors/attributes will
-    /// be used sequentially when there is a `[C]` or `[A]` marker, respectively (`[bold C]`).
-    ///
-    /// For example: `@[bold C]{status}@` will be formatted based upon
-    /// the first FormatColor constant or function in the `colors` vector,
-    /// yielding a bold and colored response status.
-    ///
-    /// Available colors are:
-    ///
-    /// - `black`
-    /// - `blue`
-    /// - `brightblack`
-    /// - `brightblue`
-    /// - `brightcyan`
-    /// - `brightgreen`
-    /// - `brightmagenta`
-    /// - `brightred`
-    /// - `brightwhite`
-    /// - `brightyellow`
-    /// - `cyan`
-    /// - `green`
-    /// - `magenta`
-    /// - `red`
-    /// - `white`
-    /// - `yellow`
-    ///
-    /// Available attributes are:
-    ///
-    /// - `bold`
-    /// - `dim`
-    /// - `italic`
-    /// - `underline`
-    /// - `blink`
-    /// - `standout`
-    /// - `reverse`
-    /// - `secure`
-    pub fn new(s: &str, colors: Vec<FormatColor>, attrs: Vec<FormatAttr>)
-            -> Option<Format> {
+    pub fn new(s: &str) -> Option<Format> {
 
-        let parser = FormatParser::new(s.chars().peekable(),
-                                       colors.into_iter(),
-                                       attrs.into_iter());
+        let parser = FormatParser::new(s.chars().peekable());
 
         let mut results = Vec::new();
 
@@ -123,12 +50,6 @@ struct FormatParser<'a> {
     // The characters of the format string.
     chars: Peekable<Chars<'a>>,
 
-    // Passed-in FormatColors
-    colors: IntoIter<FormatColor>,
-
-    // Passed-in FormatAttr
-    attrs: IntoIter<FormatAttr>,
-
     // A reusable buffer for parsing style attributes.
     object_buffer: String,
 
@@ -140,12 +61,9 @@ struct FormatParser<'a> {
 }
 
 impl<'a> FormatParser<'a> {
-    fn new(chars: Peekable<Chars>, colors: IntoIter<FormatColor>,
-           attrs: IntoIter<FormatAttr>) -> FormatParser {
+    fn new(chars: Peekable<Chars>) -> FormatParser {
         FormatParser {
             chars: chars,
-            colors: colors,
-            attrs: attrs,
 
             // No attributes are longer than 14 characters, so we can avoid reallocating.
             object_buffer: String::with_capacity(14),
@@ -207,105 +125,7 @@ impl<'a> Iterator for FormatParser<'a> {
                     }
                 };
 
-                Some(Some(FormatUnit {
-                    text: text,
-                    color: ConstantColor(None),
-                    attrs: ConstantAttrs(vec![])
-                }))
-            },
-
-            // Parse an attribute and the thing it applies to.
-            //
-            // The form is:
-            //   - @[attributes]target@
-            Some('@') => {
-                match self.chars.next() {
-                    // Parse attributes
-                    Some('[') => {
-                        let mut buffer = String::new();
-
-                        loop {
-                            match self.chars.next() {
-                                // Finished parsing into buffer.
-                                Some(']') => break,
-                                Some(c) => buffer.push(c),
-                                // Error, so mark as finished.
-                                None => {
-                                    self.finished = true;
-                                    return Some(None);
-                                }
-                            }
-                        }
-
-                        let mut attrs = ConstantAttrs(vec![]);
-                        let mut color = ConstantColor(None);
-
-                        // Collect the attributes into attrs and color, for use as properties
-                        // of a FormatUnit.
-                        for word in buffer.split(|c: char| c.is_whitespace()) {
-                            match word {
-                                "A" => attrs = self.attrs.next().unwrap_or(ConstantAttrs(vec![])),
-
-                                "C" => color = self.colors.next().unwrap_or(ConstantColor(None)),
-
-                                style => match style.parse() {
-                                    Ok(Color(c)) => match color {
-                                        ConstantColor(_) => { color = ConstantColor(Some(c)); },
-                                        _ => {}
-                                    },
-
-                                    Ok(Attr(a)) => match attrs {
-                                        ConstantAttrs(ref mut v) => { v.push(a); },
-                                        _ => {}
-                                    },
-
-                                    _ => {}
-                                }
-                            }
-                        }
-
-                        // Nested attributes are not supported.
-                        if self.chars.peek() == Some(&'@') {
-                            self.finished = true;
-                            return Some(None);
-                        }
-
-                        // Now we have the parsed attributes, so we can parse what they apply to.
-                        let mut apply_to = vec![];
-
-                        loop {
-                            match self.next() {
-                                Some(Some(unit)) => apply_to.push(unit),
-                                _ => {
-                                    self.finished = true;
-                                    return Some(None);
-                                }
-                            };
-
-                            if self.chars.peek() == Some(&'@') {
-                                // Jump over the closing '@'
-                                self.chars.next();
-                                break;
-                            }
-                        }
-
-                        self.waitqueue.extend(apply_to.into_iter().map(|unit| {
-                            FormatUnit {
-                                text: unit.text,
-                                color: color.clone(),
-                                attrs: attrs.clone()
-                            }
-                        }));
-
-                        self.next()
-                    },
-
-                    _ => {
-                        // Error, so mark as finished.
-                        self.finished = true;
-                        return Some(None);
-                    }
-                }
+                Some(Some(FormatUnit {text: text}))
             },
 
             // Parse a regular string part of the format string.
@@ -316,12 +136,8 @@ impl<'a> Iterator for FormatParser<'a> {
                 loop {
                     match self.chars.peek() {
                         // Done parsing.
-                        Some(&'@') | Some(&'{') | None => {
-                            return Some(Some(FormatUnit {
-                                text: FormatText::Str(buffer),
-                                color: ConstantColor(None),
-                                attrs: ConstantAttrs(vec![])
-                            }))
+                        Some(&'{') | None => {
+                            return Some(Some(FormatUnit {text: FormatText::Str(buffer)}))
                         },
 
                         Some(_) => {
@@ -333,81 +149,6 @@ impl<'a> Iterator for FormatParser<'a> {
 
             // Reached end of the format string.
             None => None
-        }
-    }
-}
-
-impl FromStr for ColorOrAttr {
-    type Err = ();
-
-    fn from_str(name: &str) -> Result<ColorOrAttr, ()> {
-        match name {
-            "black" => Ok(Color(color::BLACK)),
-            "blue" => Ok(Color(color::BLUE)),
-            "brightblack" => Ok(Color(color::BRIGHT_BLACK)),
-            "brightblue" => Ok(Color(color::BRIGHT_BLUE)),
-            "brightcyan" => Ok(Color(color::BRIGHT_CYAN)),
-            "brightgreen" => Ok(Color(color::BRIGHT_GREEN)),
-            "brightmagenta" => Ok(Color(color::BRIGHT_MAGENTA)),
-            "brightred" => Ok(Color(color::BRIGHT_RED)),
-            "brightwhite" => Ok(Color(color::BRIGHT_WHITE)),
-            "brightyellow" => Ok(Color(color::BRIGHT_YELLOW)),
-            "cyan" => Ok(Color(color::CYAN)),
-            "green" => Ok(Color(color::GREEN)),
-            "magenta" => Ok(Color(color::MAGENTA)),
-            "red" => Ok(Color(color::RED)),
-            "white" => Ok(Color(color::WHITE)),
-            "yellow" => Ok(Color(color::YELLOW)),
-
-            "bold" => Ok(Attr(term::Attr::Bold)),
-            "dim" => Ok(Attr(term::Attr::Dim)),
-            "italic" => Ok(Attr(term::Attr::Italic(true))),
-            "underline" => Ok(Attr(term::Attr::Underline(true))),
-            "blink" => Ok(Attr(term::Attr::Blink)),
-            "standout" => Ok(Attr(term::Attr::Standout(true))),
-            "reverse" => Ok(Attr(term::Attr::Reverse)),
-            "secure" => Ok(Attr(term::Attr::Secure)),
-
-            _ => Err(())
-        }
-    }
-}
-
-enum ColorOrAttr {
-    Color(color::Color),
-    Attr(term::Attr)
-}
-
-/// A representation of color in a `FormatUnit`.
-#[derive(Copy)]
-pub enum FormatColor {
-    /// A constant color
-    ConstantColor(Option<color::Color>),
-    /// A variable color, dependent on the request/response
-    ///
-    /// This can be used to change the color depending on response status, &c.
-    FunctionColor(fn(&Request, &Response) -> Option<color::Color>)
-}
-
-/// A representation of attributes in a `FormatUnit`.
-pub enum FormatAttr {
-    /// A constant attribute
-    ConstantAttrs(Vec<term::Attr>),
-    /// A variable attribute, dependent on the request/response
-    ///
-    /// This can be used to change the attribute depending on response status, &c.
-    FunctionAttrs(fn(&Request, &Response) -> Vec<term::Attr>)
-}
-
-impl Clone for FormatColor {
-    fn clone(&self) -> FormatColor { *self }
-}
-
-impl Clone for FormatAttr {
-    fn clone(&self) -> FormatAttr {
-        match *self {
-            ConstantAttrs(ref attrs) => ConstantAttrs(attrs.iter().map(|&attr| attr).collect()),
-            FunctionAttrs(f) => FunctionAttrs(f)
         }
     }
 }
@@ -431,6 +172,4 @@ pub enum FormatText {
 #[doc(hidden)]
 pub struct FormatUnit {
     pub text: FormatText,
-    pub color: FormatColor,
-    pub attrs: FormatAttr
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,19 +3,13 @@
 //! Request logging middleware for Iron
 
 extern crate iron;
-extern crate term;
+#[macro_use] extern crate log;
 extern crate time;
 
-use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Response, status};
+use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Response};
 use iron::typemap::Key;
-use term::{StdoutTerminal, color, stdout};
-
-use std::io;
-use std::io::Write;
 
 use format::FormatText::{Str, Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
-use format::FormatColor::{ConstantColor, FunctionColor};
-use format::FormatAttr::{ConstantAttrs, FunctionAttrs};
 use format::{Format, FormatText};
 
 pub mod format;
@@ -63,15 +57,6 @@ impl Logger {
         let Format(format) = self.format.clone().unwrap_or_default();
 
         {
-            macro_rules! tryio {
-                ($expr:expr) => (match $expr {
-                    std::result::Result::Ok(val) => val,
-                    std::result::Result::Err(err) => {
-                        return Err(IronError::new(err, status::InternalServerError))
-                    }
-                })
-            }
-
             let render = |text: &FormatText| {
                 match *text {
                     Str(ref string) => string.clone(),
@@ -86,85 +71,10 @@ impl Logger {
                 }
             };
 
-            let log = |w: &mut LogWriter| -> IronResult<()> {
-                for unit in format.iter() {
-                    let c = match unit.color {
-                        ConstantColor(color) => color,
-                        FunctionColor(f) => f(req, res)
-                    };
-                    let fn_attrs;
-                    let ref attrs = match unit.attrs {
-                        ConstantAttrs(ref attrs) => attrs,
-                        FunctionAttrs(f) => {
-                            fn_attrs = f(req, res);
-                            &fn_attrs
-                        }
-                    };
-                    tryio!(w.write_item(render(&unit.text), c, attrs));
-                }
-                tryio!(w.new_line());
-                Ok(())
-            };
-
-            match stdout() {
-                Some(terminal) => {
-                    try!(log(&mut TermWriter::new(terminal)));
-                }
-                None => {
-                    try!(log(&mut io::stdout()));
-                }
-            };
+            let lg = format.iter().map(|unit| render(&unit.text)).collect::<Vec<String>>().join("");
+            info!("{}", lg);
         }
 
-        Ok(())
-    }
-}
-
-trait LogWriter {
-    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> io::Result<()>;
-    fn new_line(&mut self) -> io::Result<()>;
-}
-
-struct TermWriter {
-    term: Box<StdoutTerminal>
-}
-
-impl TermWriter {
-    fn new(term: Box<StdoutTerminal>) -> TermWriter {
-        TermWriter {
-            term: term
-        }
-    }
-}
-
-impl LogWriter for TermWriter {
-    fn write_item(&mut self, text: String, color: Option<color::Color>, attrs: &Vec<term::Attr>) -> io::Result<()> {
-        match color {
-            Some(c) => { try!(self.term.fg(c)); }
-            None => {},
-        }
-        for &attr in attrs.iter() {
-            try!(self.term.attr(attr));
-        }
-        try!(write!(self.term, "{}", text));
-        try!(self.term.reset());
-        Ok(())
-    }
-
-    fn new_line(&mut self) -> io::Result<()> {
-        try!(writeln!(self.term, ""));
-        Ok(())
-    }
-}
-
-impl<T: Write> LogWriter for T {
-    fn write_item(&mut self, text: String, _: Option<color::Color>, _: &Vec<term::Attr>) -> io::Result<()> {
-        try!(write!(self, "{}", text));
-        Ok(())
-    }
-
-    fn new_line(&mut self) -> io::Result<()> {
-        try!(writeln!(self, ""));
         Ok(())
     }
 }


### PR DESCRIPTION
Remove support for logging to terminal, as well as using color and text attributes,
relying simply on log module to deliver the message. I've tested it with stdio_logger create.
This is based on Alexander Irbis fork.