### PR TITLE
Document examples about new strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT"
 iron = { version = "0.4", default-features = false }
 log = "0.3.6"
 time = "0.1.35"
+
+[dev-dependencies]
+env_logger = "0.3.5"

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -1,6 +1,7 @@
 //! Example of a simple logger
 extern crate iron;
 extern crate logger;
+extern crate env_logger;
 
 use iron::prelude::*;
 use logger::Logger;
@@ -8,6 +9,8 @@ use logger::Logger;
 // Logger has a default formatting of the strings printed
 // to console.
 fn main() {
+    env_logger::init().unwrap();
+
     let (logger_before, logger_after) = Logger::new(None);
 
     let mut chain = Chain::new(no_op_handler);
@@ -18,7 +21,11 @@ fn main() {
     // Link logger_after as your *last* after middleware.
     chain.link_after(logger_after);
 
-    Iron::new(chain).http("127.0.0.1:3000").unwrap();
+    println!("Run `RUST_LOG=logger=info cargo run --example default` to see logs.");
+    match Iron::new(chain).http("127.0.0.1:3000") {
+        Result::Ok(listening) => println!("{:?}", listening),
+        Result::Err(err) => panic!("{:?}", err),
+    }
 }
 
 fn no_op_handler(_: &mut Request) -> IronResult<Response> {

--- a/examples/formatstring.rs
+++ b/examples/formatstring.rs
@@ -1,6 +1,7 @@
 //! Example of logger with custom formatting
 extern crate iron;
 extern crate logger;
+extern crate env_logger;
 
 use iron::prelude::*;
 
@@ -13,10 +14,17 @@ static FORMAT: &'static str =
 // This is an example of using a format string that can specify colors and attributes
 // to specific words that are printed out to the console.
 fn main() {
+    env_logger::init().unwrap();
+
     let mut chain = Chain::new(no_op_handler);
     let format = Format::new(FORMAT);
     chain.link(Logger::new(Some(format.unwrap())));
-    Iron::new(chain).http("localhost:3000").unwrap();
+	
+    println!("Run `RUST_LOG=info cargo run --example formatstring` to see logs.");
+    match Iron::new(chain).http("127.0.0.1:3000") {
+        Result::Ok(listening) => println!("{:?}", listening),
+        Result::Err(err) => panic!("{:?}", err),
+    }
 }
 
 fn no_op_handler(_: &mut Request) -> IronResult<Response> {


### PR DESCRIPTION
Show off using `env_logger` and tell the user how to see logs.