### PR TITLE
Stop allocating so much while formatting.

### DIFF
--- a/examples/formatstring.rs
+++ b/examples/formatstring.rs
@@ -6,7 +6,7 @@ extern crate env_logger;
 use iron::prelude::*;
 
 use logger::Logger;
-use logger::format::Format;
+use logger::Format;
 
 static FORMAT: &'static str =
     "Uri: {uri}, Method: {method}, Status: {status}, Duration: {response-time}, Time: {request-time}";
@@ -19,7 +19,7 @@ fn main() {
     let mut chain = Chain::new(no_op_handler);
     let format = Format::new(FORMAT);
     chain.link(Logger::new(Some(format.unwrap())));
-	
+
     println!("Run `RUST_LOG=info cargo run --example formatstring` to see logs.");
     match Iron::new(chain).http("127.0.0.1:3000") {
         Result::Ok(listening) => println!("{:?}", listening),

--- a/src/format.rs
+++ b/src/format.rs
@@ -186,7 +186,6 @@ pub struct FormatUnit {
 }
 
 
-#[doc(hidden)]
 pub struct FormatDisplay<'a> {
     format: &'a Format,
     render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>,

--- a/src/format.rs
+++ b/src/format.rs
@@ -45,15 +45,27 @@ impl Format {
 
         Some(Format(results))
     }
-
 }
 
-pub fn display_with<'a>(format: &'a Format,
-                        render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
-                        -> FormatDisplay<'a> {
-    FormatDisplay {
-        format: format,
-        render: render,
+pub trait ContextDisplay<'a> {
+    type Item;
+    type Display: fmt::Display;
+    fn display_with(&'a self,
+                    render: &'a Fn(&mut Formatter, &Self::Item) -> Result<(), fmt::Error>)
+                    -> Self::Display;
+}
+
+
+impl<'a> ContextDisplay<'a> for Format {
+    type Item = FormatText;
+    type Display = FormatDisplay<'a>;
+    fn display_with(&'a self,
+                    render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
+                    -> FormatDisplay<'a> {
+        FormatDisplay {
+            format: self,
+            render: render,
+        }
     }
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -10,7 +10,7 @@ use self::FormatText::{Method, URI, Status, ResponseTime, RemoteAddr, RequestTim
 /// A formatting style for the `Logger`, consisting of multiple
 /// `FormatUnit`s concatenated into one line.
 #[derive(Clone)]
-pub struct Format(pub Vec<FormatUnit>);
+pub struct Format(Vec<FormatUnit>);
 
 impl Default for Format {
     /// Return the default formatting style for the `Logger`:
@@ -46,14 +46,14 @@ impl Format {
         Some(Format(results))
     }
 
-    /// Turn a `Format` into something that can be displayed.
-    pub fn display_with<'a>(&'a self,
-                            render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
-                            -> FormatDisplay<'a> {
-        FormatDisplay {
-            format: self,
-            render: render,
-        }
+}
+
+pub fn display_with<'a>(format: &'a Format,
+                        render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
+                        -> FormatDisplay<'a> {
+    FormatDisplay {
+        format: format,
+        render: render,
     }
 }
 
@@ -186,7 +186,6 @@ pub struct FormatUnit {
 }
 
 
-/// A helper for displaying a log message.
 #[doc(hidden)]
 pub struct FormatDisplay<'a> {
     format: &'a Format,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Re
 use iron::typemap::Key;
 
 use format::FormatText::{Str, Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
-use format::{FormatText};
+use format::{ContextDisplay, FormatText};
 
 use std::fmt::{Display, Formatter};
 
@@ -81,7 +81,7 @@ impl Logger {
                 }
             };
 
-            info!("{}", format::display_with(&self.format, &render));
+            info!("{}", self.format.display_with(&render));
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use iron::typemap::Key;
 use format::FormatText::{Str, Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
 use format::{FormatText};
 
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 
 mod format;
 pub use format::Format;
@@ -63,19 +63,21 @@ impl Logger {
             let render = |fmt: &mut Formatter, text: &FormatText| {
                 match *text {
                     Str(ref string) => fmt.write_str(string),
-                    Method => fmt.write_fmt(format_args!("{}", req.method)),
-                    URI => fmt.write_fmt(format_args!("{}", req.url)),
-                    Status => match res.status {
-                        Some(status) => fmt.write_fmt(format_args!("{}", status)),
-                        None => fmt.write_str("<missing status code>"),
-                    },
+                    Method => req.method.fmt(fmt),
+                    URI => req.url.fmt(fmt),
+                    Status => {
+                        match res.status {
+                            Some(status) => status.fmt(fmt),
+                            None => fmt.write_str("<missing status code>"),
+                        }
+                    }
                     ResponseTime => fmt.write_fmt(format_args!("{} ms", response_time_ms)),
-                    RemoteAddr => fmt.write_fmt(format_args!("{}", req.remote_addr)),
+                    RemoteAddr => req.remote_addr.fmt(fmt),
                     RequestTime => {
-                        fmt.write_fmt(format_args!("{}",
-                                                   entry_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ%z")
-                                                   .unwrap()))
-                    },
+                        entry_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ%z")
+                            .unwrap()
+                            .fmt(fmt)
+                    }
                 }
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,13 @@ use iron::typemap::Key;
 use format::FormatText::{Str, Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
 use format::{Format, FormatText};
 
+use std::fmt::Formatter;
+
 pub mod format;
 
 /// `Middleware` for logging request and response info to the terminal.
 pub struct Logger {
-    format: Option<Format>
+    format: Format,
 }
 
 impl Logger {
@@ -37,6 +39,7 @@ impl Logger {
     /// chain.link_after(logger_after);
     /// ```
     pub fn new(format: Option<Format>) -> (Logger, Logger) {
+        let format = format.unwrap_or_default();
         (Logger { format: format.clone() }, Logger { format: format })
     }
 }
@@ -54,25 +57,28 @@ impl Logger {
 
         let response_time = time::now() - entry_time;
         let response_time_ms = (response_time.num_seconds() * 1000) as f64 + (response_time.num_nanoseconds().unwrap_or(0) as f64) / 1000000.0;
-        let Format(format) = self.format.clone().unwrap_or_default();
 
         {
-            let render = |text: &FormatText| {
+            let render = |fmt: &mut Formatter, text: &FormatText| {
                 match *text {
-                    Str(ref string) => string.clone(),
-                    Method => format!("{}", req.method),
-                    URI => format!("{}", req.url),
-                    Status => res.status
-                        .map(|status| format!("{}", status))
-                        .unwrap_or("<missing status code>".to_owned()),
-                    ResponseTime => format!("{} ms", response_time_ms),
-                    RemoteAddr => format!("{}", req.remote_addr),
-                    RequestTime => format!("{}", entry_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ%z").unwrap()),
+                    Str(ref string) => fmt.write_str(string),
+                    Method => fmt.write_fmt(format_args!("{}", req.method)),
+                    URI => fmt.write_fmt(format_args!("{}", req.url)),
+                    Status => match res.status {
+                        Some(status) => fmt.write_fmt(format_args!("{}", status)),
+                        None => fmt.write_str("<missing status code>"),
+                    },
+                    ResponseTime => fmt.write_fmt(format_args!("{} ms", response_time_ms)),
+                    RemoteAddr => fmt.write_fmt(format_args!("{}", req.remote_addr)),
+                    RequestTime => {
+                        fmt.write_fmt(format_args!("{}",
+                                                   entry_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ%z")
+                                                   .unwrap()))
+                    },
                 }
             };
 
-            let lg = format.iter().map(|unit| render(&unit.text)).collect::<Vec<String>>().join("");
-            info!("{}", lg);
+            info!("{}", self.format.display_with(&render));
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,12 @@ use iron::{AfterMiddleware, BeforeMiddleware, IronResult, IronError, Request, Re
 use iron::typemap::Key;
 
 use format::FormatText::{Str, Method, URI, Status, ResponseTime, RemoteAddr, RequestTime};
-use format::{Format, FormatText};
+use format::{FormatText};
 
 use std::fmt::Formatter;
 
-pub mod format;
+mod format;
+pub use format::Format;
 
 /// `Middleware` for logging request and response info to the terminal.
 pub struct Logger {
@@ -78,7 +79,7 @@ impl Logger {
                 }
             };
 
-            info!("{}", self.format.display_with(&render));
+            info!("{}", format::display_with(&self.format, &render));
         }
 
         Ok(())


### PR DESCRIPTION
See #41.

This is a breaking change, as it cleans up the public API by hiding the details of formatting.