### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-
 name = "logger"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Alexander Irbis <irbis.labs@gmail.com>", "Jonathan Reem <jonathan.reem@gmail.com>", "Michael Reinhard <mcreinhard@gmail.com>"]
 description = "Logging middleware for the Iron framework."
 repository = "https://github.com/iron/logger"


### PR DESCRIPTION
0.4.0 has already been released, but the version bump commit was missing: https://crates.io/crates/logger

CC @untitaker