### PR TITLE
Update log to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT"
 
 [dependencies]
 iron = { version = ">=0.4,<0.7.0", default-features = false }
-log = "0.3.8"
+log = "0.4.1"
 time = "0.1.35"
 
 [dev-dependencies]
-env_logger = "0.4.3"
+env_logger = "0.5.3"

--- a/examples/default.rs
+++ b/examples/default.rs
@@ -9,7 +9,7 @@ use logger::Logger;
 // Logger has a default formatting of the strings printed
 // to console.
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let (logger_before, logger_after) = Logger::new(None);
 

--- a/examples/formatstring.rs
+++ b/examples/formatstring.rs
@@ -14,7 +14,7 @@ static FORMAT: &'static str =
 // This is an example of using a format string that can specify colors and attributes
 // to specific words that are printed out to the console.
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let mut chain = Chain::new(no_op_handler);
     let format = Format::new(FORMAT);


### PR DESCRIPTION
Hi! 

This just bumps `log` version to 0.4, which is important because 0.3 and 0.4 are not 100% compatible.

I haven't actually verified that it works as expected, but `cargo test` passes, and the changes are trivial 😆 