### PR TITLE
Fix double counted secs

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -51,7 +51,7 @@ pub trait ContextDisplay<'a> {
     type Item;
     type Display: fmt::Display;
     fn display_with(&'a self,
-                    render: &'a Fn(&mut Formatter, &Self::Item) -> Result<(), fmt::Error>)
+                    render: &'a dyn Fn(&mut Formatter, &Self::Item) -> Result<(), fmt::Error>)
                     -> Self::Display;
 }
 
@@ -60,7 +60,7 @@ impl<'a> ContextDisplay<'a> for Format {
     type Item = FormatText;
     type Display = FormatDisplay<'a>;
     fn display_with(&'a self,
-                    render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
+                    render: &'a dyn Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>)
                     -> FormatDisplay<'a> {
         FormatDisplay {
             format: self,
@@ -182,7 +182,7 @@ pub enum FormatText {
 
 pub struct FormatDisplay<'a> {
     format: &'a Format,
-    render: &'a Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>,
+    render: &'a dyn Fn(&mut Formatter, &FormatText) -> Result<(), fmt::Error>,
 }
 
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,12 +102,12 @@ impl BeforeMiddleware for Logger {
 
 impl AfterMiddleware for Logger {
     fn after(&self, req: &mut Request, res: Response) -> IronResult<Response> {
-        try!(self.log(req, &res));
+        self.log(req, &res)?;
         Ok(res)
     }
 
     fn catch(&self, req: &mut Request, err: IronError) -> IronResult<Response> {
-        try!(self.log(req, &err.response));
+        self.log(req, &err.response)?;
         Err(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ impl Logger {
         let entry_time = *req.extensions.get::<StartTime>().unwrap();
 
         let response_time = time::now() - entry_time;
-        let response_time_ms = (response_time.num_seconds() * 1000) as f64 + (response_time.num_nanoseconds().unwrap_or(0) as f64) / 1000000.0;
+        let response_time_ms = (response_time.num_nanoseconds().unwrap_or(0) as f64) / 1000000.0;
 
         {
             let render = |fmt: &mut Formatter, text: &FormatText| {


### PR DESCRIPTION
Hi

I found an issue that it reports wrong response time when a processing time takes over a second.
`num_nanoseconds()` also returns seconds part so we don't have to add it again.